### PR TITLE
"Fix config dispatch key naming and multi-GPU summary grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,15 +288,15 @@ Each benchmark has its own `--precision-<test>` flag. The available data types v
 |-----------|:---------:|:----------:|:---------:|:---------:|:-----------:|:------------:|---------|
 | Batched GEMM | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | float32 |
 | Convolution | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | float32 |
-| FFT | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | float32 |
+| FFT | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | float32 |
 | Einsum | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | float32 |
 | Memory Traffic | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | float32 |
 | Heat Equation | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | float32 |
 | Schrödinger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | float32 |
-| **Atomic Contention** | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | float32 |
+| **Atomic Contention** | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | float32 |
 | **Sparse MM** | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | float32 |
 
-> **Note:** Atomic Contention does not support complex types. Sparse MM only supports `float32` and `float64` (PyTorch limitation for `torch.sparse.mm`). Using TF32 mode (`--batched-gemm-TF32-mode`) forces `float32` regardless of `--precision-gemm`.
+> **Note:** FFT does not support `bfloat16` (`torch.fft.fftn` limitation). Atomic Contention and Sparse MM only support `float32` and `float64`. Using TF32 mode (`--batched-gemm-TF32-mode`) forces `float32` regardless of `--precision-gemm`.
 
 ### Batched GEMM
 | Option | Description |
@@ -461,7 +461,7 @@ CLI arguments override YAML settings:
 ./torch-hammer.py --config config.yaml --verbose-file-only
 ```
 
-See `config-examples/` directory for ready-to-use configurations (`quick-test.yaml`, `stress-test.yaml`).
+See `config-examples/` directory for ready-to-use configurations (`quick-test.yaml`, `stress-test.yaml`, `platform-stress.yaml`).
 
 ---
 

--- a/config-examples/README.md
+++ b/config-examples/README.md
@@ -25,7 +25,7 @@ Override config settings via CLI:
 |------|---------|----------|
 | `quick-test.yaml` | Fast sanity check | ~2 minutes |
 | `stress-test.yaml` | Comprehensive test suite | ~15-30 minutes |
-| `platform-stress.yaml` | Standardized GPU platform screening | ~5-6 minutes per GPU |
+| `platform-stress.yaml` | Full precision sweep across all benchmarks | ~30-45 minutes per GPU |
 
 ## Configuration File Format
 
@@ -76,17 +76,17 @@ runtime:
 
 ## Available Benchmarks
 
-| Name | Description | Key Parameters |
-|------|-------------|----------------|
-| `batched_gemm` | Matrix multiplication | m, n, k, batch_count |
-| `convolution` | 2D convolution | height, width, channels, kernel_size |
-| `fft` | 3D FFT | nx, ny, nz |
-| `einsum` | Attention pattern | heads, seq_len, d_model |
-| `memory_traffic` | Memory bandwidth | memory_size, memory_pattern |
-| `heat_equation` | Stencil computation | heat_grid_size, heat_time_steps |
-| `schrodinger` | Quantum simulation | schrodinger_grid_size |
-| `atomic_contention` | L2 cache stress | atomic_target_size |
-| `sparse_mm` | Sparse matrix multiply | sparse_m, sparse_n, sparse_density |
+| Name | Description | Key Parameters | Supported Precisions |
+|------|-------------|----------------|---------------------|
+| `batched_gemm` | Matrix multiplication | m, n, k, batch_count | All 6 |
+| `convolution` | 2D convolution | height, width, channels, kernel_size | All 6 |
+| `fft` | 3D FFT | nx, ny, nz | float16, float32, float64, complex64, complex128 |
+| `einsum` | Attention pattern | heads, seq_len, d_model | All 6 |
+| `memory_traffic` | Memory bandwidth | memory_size, memory_pattern | All 6 |
+| `heat_equation` | Stencil computation | heat_grid_size, heat_time_steps | All 6 |
+| `schrodinger` | Quantum simulation | schrodinger_grid_size | All 6 |
+| `atomic_contention` | L2 cache stress | atomic_target_size | float16, bfloat16, float32, float64 |
+| `sparse_mm` | Sparse matrix multiply | sparse_m, sparse_n, sparse_density | float16, bfloat16, float32, float64 |
 
 ## Precision Options
 
@@ -96,3 +96,5 @@ runtime:
 - `float64` - Double precision
 - `complex64` - Complex single
 - `complex128` - Complex double
+
+**Note:** FFT does not support `bfloat16`. Atomic contention and sparse MM do not support complex types.

--- a/config-examples/README.md
+++ b/config-examples/README.md
@@ -25,9 +25,33 @@ Override config settings via CLI:
 |------|---------|----------|
 | `quick-test.yaml` | Fast sanity check | ~2 minutes |
 | `stress-test.yaml` | Comprehensive test suite | ~15-30 minutes |
+| `platform-stress.yaml` | Standardized GPU platform screening | ~5-6 minutes per GPU |
 
 ## Configuration File Format
 
+Config files support two key naming styles:
+
+### Short generic keys (used in quick-test.yaml, stress-test.yaml)
+```yaml
+benchmarks:
+  - name: batched_gemm
+    precision: float32         # Short key
+    batch_count: 128           # Short key
+    inner_loop: 50             # Short key
+```
+
+### Full argparse attribute names (used in platform-stress.yaml)
+```yaml
+benchmarks:
+  - name: batched_gemm
+    precision_gemm: float32    # Full attribute name
+    batch_count_gemm: 128      # Full attribute name
+    inner_loop_batched_gemm: 50  # Full attribute name
+```
+
+Both styles work in all config files. Short keys are checked first for backwards compatibility.
+
+### Global settings
 ```yaml
 profile: "Descriptive Name"
 description: "What this config does"
@@ -38,15 +62,10 @@ global:
   all_gpus: true          # Run on all GPUs
   cpu_affinity: true      # NUMA-aware CPU binding
 
-benchmarks:
-  - name: batched_gemm    # Benchmark name
-    enabled: true         # Enable/disable
-    precision: float32    # Data type
-    batch_count: 128      # Batch size
-    m: 4096               # Matrix dimensions
-    n: 4096
-    k: 4096
-    inner_loop: 50        # Iterations
+runtime:
+  duration: 60            # Run each benchmark for 60s
+  temp_warn_C: 85.0       # Temperature warning threshold
+  temp_critical_C: 92.0   # Temperature critical threshold
 ```
 
 ## Creating Custom Configurations

--- a/config-examples/platform-stress.yaml
+++ b/config-examples/platform-stress.yaml
@@ -1,0 +1,98 @@
+# Torch Hammer Configuration: Platform Performance Screen
+#
+# A standardized "measuring stick" config for comparing GPU platforms.
+# Uses --stress-test to auto-size tensors to fill available GPU memory,
+# and --duration to run each benchmark for a fixed wall-clock window.
+#
+# Usage:
+#   python torch-hammer.py --config config-examples/platform-stress.yaml \
+#       --stress-test --all-gpus --json-output results.json
+#
+# Quick single-GPU run:
+#   python torch-hammer.py --config config-examples/platform-stress.yaml \
+#       --stress-test --device-index 0 --summary-csv summary.csv
+#
+# What this measures:
+#   • GEMM (fp32 + fp64)     — peak compute at both precisions
+#   • Convolution (fp32)      — CNN-style workload throughput
+#   • Einsum (fp32)           — transformer attention throughput
+#   • FFT (fp32)              — spectral methods / signal processing
+#   • Memory streaming (fp32) — sustained memory bandwidth
+#   • Memory random (fp32)    — random-access latency / bandwidth
+#   • Heat equation (fp32)    — stencil compute (memory+compute mixed)
+#   • Sparse MM (fp64)        — sparse algebra throughput
+#
+# Each benchmark runs for 20s after warmup. Total runtime ~5-6 minutes
+# per GPU (9 benchmarks × ~30s each including warmup).
+
+profile: "Platform Performance Screen"
+description: "Standardized GPU performance screening — auto-sized to fill memory"
+
+global:
+  warmup: 10
+  duration: 20
+  all_gpus: true
+  verbose: true
+
+runtime:
+  temp_warn_C: 85.0
+  temp_critical_C: 92.0
+  power_warn_pct: 95.0
+
+benchmarks:
+  # ── Peak Compute ────────────────────────────────────────────
+  # FP32 GEMM: the single most important GPU benchmark
+  - name: batched_gemm
+    precision_gemm: float32
+    batch_count_gemm: 64
+
+  # FP64 GEMM: scientific computing / HPC workloads
+  - name: batched_gemm
+    precision_gemm: float64
+    batch_count_gemm: 64
+
+  # ── AI / ML Workloads ───────────────────────────────────────
+  # Convolution: ResNet-style CNN inference/training
+  - name: convolution
+    precision_convolution: float32
+    batch_count_convolution: 128
+    in_channels: 64
+    out_channels: 256
+    kernel_size: 3
+
+  # Einsum attention: transformer-style QKV attention
+  - name: einsum
+    precision_einsum: float32
+    batch_count_einsum: 64
+    heads: 32
+    d_model: 128
+
+  # ── Memory Subsystem ────────────────────────────────────────
+  # Streaming: sustained sequential bandwidth (like STREAM)
+  - name: memory_traffic
+    precision_memory: float32
+    memory_pattern: streaming
+    memory_iterations: 100
+
+  # Random access: pointer-chasing / gather bandwidth
+  - name: memory_traffic
+    precision_memory: float32
+    memory_pattern: random
+    memory_iterations: 100
+
+  # ── Scientific / HPC ────────────────────────────────────────
+  # FFT: spectral methods, signal processing
+  - name: fft
+    precision_fft: float32
+    batch_count_fft: 64
+
+  # Heat equation: Laplacian stencil (memory+compute balanced)
+  - name: heat_equation
+    precision_heat: float32
+    heat_time_steps: 1000
+
+  # ── Sparse Algebra ──────────────────────────────────────────
+  # Sparse MM: sparse × dense matmul (10% density)
+  - name: sparse_mm
+    precision_sparse: float64
+    sparse_density: 0.10

--- a/config-examples/platform-stress.yaml
+++ b/config-examples/platform-stress.yaml
@@ -17,10 +17,11 @@
 #
 # Precision coverage:
 #   Standard benchmarks: bfloat16, float16, float32, float64, complex64, complex128
+#   FFT:                 float16, float32, float64, complex64, complex128 (bfloat16 unsupported)
 #   Atomic / Sparse:     bfloat16, float16, float32, float64 (real only)
 #   Memory traffic:      float32, float64 (streaming + random patterns)
 #
-# Total: 48 benchmark entries. Estimated runtime ~30-45 minutes per GPU.
+# Total: 47 benchmark entries. Estimated runtime ~30-45 minutes per GPU.
 
 profile: "Platform Performance Screen"
 description: "Full precision sweep across all benchmarks — auto-sized to fill memory"
@@ -110,12 +111,9 @@ benchmarks:
     kernel_size: 3
 
   # ══════════════════════════════════════════════════════════════
-  # FFT — all 6 precisions
+  # FFT — float16, float32, float64, complex64, complex128
+  # (bfloat16 not supported by torch.fft.fftn)
   # ══════════════════════════════════════════════════════════════
-  - name: fft
-    precision_fft: bfloat16
-    batch_count_fft: 128
-
   - name: fft
     precision_fft: float16
     batch_count_fft: 128

--- a/config-examples/platform-stress.yaml
+++ b/config-examples/platform-stress.yaml
@@ -1,6 +1,9 @@
 # Torch Hammer Configuration: Platform Performance Screen
 #
-# A standardized "measuring stick" config for comparing GPU platforms.
+# A comprehensive stress config that runs every benchmark across all
+# supported precisions with aggressive parameters. Designed for full
+# platform characterization and regression testing.
+#
 # Uses --stress-test to auto-size tensors to fill available GPU memory,
 # and --duration to run each benchmark for a fixed wall-clock window.
 #
@@ -12,25 +15,19 @@
 #   python torch-hammer.py --config config-examples/platform-stress.yaml \
 #       --stress-test --device-index 0 --summary-csv summary.csv
 #
-# What this measures:
-#   • GEMM (fp32 + fp64)     — peak compute at both precisions
-#   • Convolution (fp32)      — CNN-style workload throughput
-#   • Einsum (fp32)           — transformer attention throughput
-#   • FFT (fp32)              — spectral methods / signal processing
-#   • Memory streaming (fp32) — sustained memory bandwidth
-#   • Memory random (fp32)    — random-access latency / bandwidth
-#   • Heat equation (fp32)    — stencil compute (memory+compute mixed)
-#   • Sparse MM (fp64)        — sparse algebra throughput
+# Precision coverage:
+#   Standard benchmarks: bfloat16, float16, float32, float64, complex64, complex128
+#   Atomic / Sparse:     bfloat16, float16, float32, float64 (real only)
+#   Memory traffic:      float32, float64 (streaming + random patterns)
 #
-# Each benchmark runs for 20s after warmup. Total runtime ~5-6 minutes
-# per GPU (9 benchmarks × ~30s each including warmup).
+# Total: 48 benchmark entries. Estimated runtime ~30-45 minutes per GPU.
 
 profile: "Platform Performance Screen"
-description: "Standardized GPU performance screening — auto-sized to fill memory"
+description: "Full precision sweep across all benchmarks — auto-sized to fill memory"
 
 global:
   warmup: 10
-  duration: 20
+  duration: 30
   all_gpus: true
   verbose: true
 
@@ -40,59 +37,263 @@ runtime:
   power_warn_pct: 95.0
 
 benchmarks:
-  # ── Peak Compute ────────────────────────────────────────────
-  # FP32 GEMM: the single most important GPU benchmark
+  # ══════════════════════════════════════════════════════════════
+  # BATCHED GEMM — all 6 precisions
+  # ══════════════════════════════════════════════════════════════
+  - name: batched_gemm
+    precision_gemm: bfloat16
+    batch_count_gemm: 128
+
+  - name: batched_gemm
+    precision_gemm: float16
+    batch_count_gemm: 128
+
   - name: batched_gemm
     precision_gemm: float32
-    batch_count_gemm: 64
+    batch_count_gemm: 128
 
-  # FP64 GEMM: scientific computing / HPC workloads
   - name: batched_gemm
     precision_gemm: float64
+    batch_count_gemm: 128
+
+  - name: batched_gemm
+    precision_gemm: complex64
     batch_count_gemm: 64
 
-  # ── AI / ML Workloads ───────────────────────────────────────
-  # Convolution: ResNet-style CNN inference/training
+  - name: batched_gemm
+    precision_gemm: complex128
+    batch_count_gemm: 64
+
+  # ══════════════════════════════════════════════════════════════
+  # CONVOLUTION — all 6 precisions
+  # ══════════════════════════════════════════════════════════════
+  - name: convolution
+    precision_convolution: bfloat16
+    batch_count_convolution: 256
+    in_channels: 128
+    out_channels: 512
+    kernel_size: 3
+
+  - name: convolution
+    precision_convolution: float16
+    batch_count_convolution: 256
+    in_channels: 128
+    out_channels: 512
+    kernel_size: 3
+
   - name: convolution
     precision_convolution: float32
+    batch_count_convolution: 256
+    in_channels: 128
+    out_channels: 512
+    kernel_size: 3
+
+  - name: convolution
+    precision_convolution: float64
     batch_count_convolution: 128
+    in_channels: 128
+    out_channels: 512
+    kernel_size: 3
+
+  - name: convolution
+    precision_convolution: complex64
+    batch_count_convolution: 64
     in_channels: 64
     out_channels: 256
     kernel_size: 3
 
-  # Einsum attention: transformer-style QKV attention
+  - name: convolution
+    precision_convolution: complex128
+    batch_count_convolution: 64
+    in_channels: 64
+    out_channels: 256
+    kernel_size: 3
+
+  # ══════════════════════════════════════════════════════════════
+  # FFT — all 6 precisions
+  # ══════════════════════════════════════════════════════════════
+  - name: fft
+    precision_fft: bfloat16
+    batch_count_fft: 128
+
+  - name: fft
+    precision_fft: float16
+    batch_count_fft: 128
+
+  - name: fft
+    precision_fft: float32
+    batch_count_fft: 128
+
+  - name: fft
+    precision_fft: float64
+    batch_count_fft: 64
+
+  - name: fft
+    precision_fft: complex64
+    batch_count_fft: 64
+
+  - name: fft
+    precision_fft: complex128
+    batch_count_fft: 64
+
+  # ══════════════════════════════════════════════════════════════
+  # EINSUM ATTENTION — all 6 precisions
+  # ══════════════════════════════════════════════════════════════
+  - name: einsum
+    precision_einsum: bfloat16
+    batch_count_einsum: 128
+    heads: 32
+    d_model: 128
+
+  - name: einsum
+    precision_einsum: float16
+    batch_count_einsum: 128
+    heads: 32
+    d_model: 128
+
   - name: einsum
     precision_einsum: float32
+    batch_count_einsum: 128
+    heads: 32
+    d_model: 128
+
+  - name: einsum
+    precision_einsum: float64
     batch_count_einsum: 64
     heads: 32
     d_model: 128
 
-  # ── Memory Subsystem ────────────────────────────────────────
-  # Streaming: sustained sequential bandwidth (like STREAM)
+  - name: einsum
+    precision_einsum: complex64
+    batch_count_einsum: 32
+    heads: 16
+    d_model: 128
+
+  - name: einsum
+    precision_einsum: complex128
+    batch_count_einsum: 32
+    heads: 16
+    d_model: 128
+
+  # ══════════════════════════════════════════════════════════════
+  # MEMORY TRAFFIC — float32 + float64, streaming + random
+  # ══════════════════════════════════════════════════════════════
   - name: memory_traffic
     precision_memory: float32
     memory_pattern: streaming
-    memory_iterations: 100
+    memory_iterations: 200
 
-  # Random access: pointer-chasing / gather bandwidth
   - name: memory_traffic
     precision_memory: float32
     memory_pattern: random
-    memory_iterations: 100
+    memory_iterations: 200
 
-  # ── Scientific / HPC ────────────────────────────────────────
-  # FFT: spectral methods, signal processing
-  - name: fft
-    precision_fft: float32
-    batch_count_fft: 64
+  - name: memory_traffic
+    precision_memory: float64
+    memory_pattern: streaming
+    memory_iterations: 200
 
-  # Heat equation: Laplacian stencil (memory+compute balanced)
+  - name: memory_traffic
+    precision_memory: float64
+    memory_pattern: random
+    memory_iterations: 200
+
+  # ══════════════════════════════════════════════════════════════
+  # HEAT EQUATION — all 6 precisions
+  # ══════════════════════════════════════════════════════════════
+  - name: heat_equation
+    precision_heat: bfloat16
+    heat_time_steps: 2000
+
+  - name: heat_equation
+    precision_heat: float16
+    heat_time_steps: 2000
+
   - name: heat_equation
     precision_heat: float32
+    heat_time_steps: 2000
+
+  - name: heat_equation
+    precision_heat: float64
+    heat_time_steps: 2000
+
+  - name: heat_equation
+    precision_heat: complex64
     heat_time_steps: 1000
 
-  # ── Sparse Algebra ──────────────────────────────────────────
-  # Sparse MM: sparse × dense matmul (10% density)
+  - name: heat_equation
+    precision_heat: complex128
+    heat_time_steps: 1000
+
+  # ══════════════════════════════════════════════════════════════
+  # SCHRÖDINGER EQUATION — all 6 precisions
+  # ══════════════════════════════════════════════════════════════
+  - name: schrodinger
+    precision_schrodinger: bfloat16
+    schrodinger_time_steps: 2000
+
+  - name: schrodinger
+    precision_schrodinger: float16
+    schrodinger_time_steps: 2000
+
+  - name: schrodinger
+    precision_schrodinger: float32
+    schrodinger_time_steps: 2000
+
+  - name: schrodinger
+    precision_schrodinger: float64
+    schrodinger_time_steps: 2000
+
+  - name: schrodinger
+    precision_schrodinger: complex64
+    schrodinger_time_steps: 1000
+
+  - name: schrodinger
+    precision_schrodinger: complex128
+    schrodinger_time_steps: 1000
+
+  # ══════════════════════════════════════════════════════════════
+  # ATOMIC CONTENTION — 4 real precisions only
+  # ══════════════════════════════════════════════════════════════
+  - name: atomic_contention
+    precision_atomic: bfloat16
+    atomic_target_size: 2000000
+    atomic_num_updates: 50000000
+    atomic_contention_range: 2048
+
+  - name: atomic_contention
+    precision_atomic: float16
+    atomic_target_size: 2000000
+    atomic_num_updates: 50000000
+    atomic_contention_range: 2048
+
+  - name: atomic_contention
+    precision_atomic: float32
+    atomic_target_size: 2000000
+    atomic_num_updates: 50000000
+    atomic_contention_range: 2048
+
+  - name: atomic_contention
+    precision_atomic: float64
+    atomic_target_size: 2000000
+    atomic_num_updates: 50000000
+    atomic_contention_range: 2048
+
+  # ══════════════════════════════════════════════════════════════
+  # SPARSE MM — 4 real precisions only
+  # ══════════════════════════════════════════════════════════════
+  - name: sparse_mm
+    precision_sparse: bfloat16
+    sparse_density: 0.10
+
+  - name: sparse_mm
+    precision_sparse: float16
+    sparse_density: 0.10
+
+  - name: sparse_mm
+    precision_sparse: float32
+    sparse_density: 0.10
+
   - name: sparse_mm
     precision_sparse: float64
     sparse_density: 0.10

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -501,3 +501,127 @@ class TestApplyConfigToArgs:
         """YAML key 'syslog-dmesg' (hyphenated) should map to args.syslog_dmesg."""
         args = self._apply(th, parser, {"global": {"syslog-dmesg": True}})
         assert args.syslog_dmesg is True
+
+
+class TestConfigGet:
+    """Tests for the _config_get helper function."""
+
+    def test_first_key_found(self, th):
+        """Should return value from the first matching key."""
+        config = {'precision': 'float32', 'precision_gemm': 'float64'}
+        assert th._config_get(config, 'precision', 'precision_gemm', default='bfloat16') == 'float32'
+
+    def test_second_key_found(self, th):
+        """Should return value from the second key when first is missing."""
+        config = {'precision_gemm': 'float64'}
+        assert th._config_get(config, 'precision', 'precision_gemm', default='float32') == 'float64'
+
+    def test_default_when_no_match(self, th):
+        """Should return default when no keys match."""
+        config = {'other_key': 'value'}
+        assert th._config_get(config, 'precision', 'precision_gemm', default='float32') == 'float32'
+
+    def test_empty_config(self, th):
+        """Should return default for empty config dict."""
+        assert th._config_get({}, 'precision', default='float32') == 'float32'
+
+    def test_none_default(self, th):
+        """Should return None when no keys match and no default given."""
+        assert th._config_get({'x': 1}, 'y') is None
+
+
+class TestConfigDispatchKeys:
+    """Tests for config dispatch accepting both short and full attribute name keys."""
+
+    def _apply(self, th, parser, config):
+        """Helper: parse empty CLI, apply config, return args."""
+        import sys
+        orig = sys.argv
+        sys.argv = ["torch-hammer.py"]
+        try:
+            args = parser.parse_args([])
+            return th.apply_config_to_args(args, config)
+        finally:
+            sys.argv = orig
+
+    def test_gemm_short_keys(self, th, parser):
+        """Short keys (precision, batch_count) should work for batched_gemm."""
+        config = {
+            "benchmarks": [
+                {"name": "batched_gemm", "precision": "float64", "batch_count": 32}
+            ]
+        }
+        args = self._apply(th, parser, config)
+        assert args.benchmark_list is not None
+        assert len(args.benchmark_list) == 1
+        bench = args.benchmark_list[0]
+        assert bench['precision'] == 'float64'
+        assert bench['batch_count'] == 32
+
+    def test_gemm_full_keys(self, th, parser):
+        """Full attribute keys (precision_gemm, batch_count_gemm) should work."""
+        config = {
+            "benchmarks": [
+                {"name": "batched_gemm", "precision_gemm": "float64", "batch_count_gemm": 32}
+            ]
+        }
+        args = self._apply(th, parser, config)
+        assert args.benchmark_list is not None
+        bench = args.benchmark_list[0]
+        assert bench['precision_gemm'] == 'float64'
+        assert bench['batch_count_gemm'] == 32
+
+    def test_dual_gemm_entries_preserved(self, th, parser):
+        """Two GEMM entries with different precisions should both be in benchmark_list."""
+        config = {
+            "benchmarks": [
+                {"name": "batched_gemm", "precision_gemm": "float32"},
+                {"name": "batched_gemm", "precision_gemm": "float64"},
+            ]
+        }
+        args = self._apply(th, parser, config)
+        assert len(args.benchmark_list) == 2
+        assert args.benchmark_list[0]['precision_gemm'] == 'float32'
+        assert args.benchmark_list[1]['precision_gemm'] == 'float64'
+
+    def test_memory_traffic_pattern_in_config(self, th, parser):
+        """memory_pattern key should be preserved in benchmark_list."""
+        config = {
+            "benchmarks": [
+                {"name": "memory_traffic", "memory_pattern": "streaming"},
+                {"name": "memory_traffic", "memory_pattern": "random"},
+            ]
+        }
+        args = self._apply(th, parser, config)
+        assert len(args.benchmark_list) == 2
+        assert args.benchmark_list[0]['memory_pattern'] == 'streaming'
+        assert args.benchmark_list[1]['memory_pattern'] == 'random'
+
+    def test_disabled_benchmark_excluded(self, th, parser):
+        """Benchmarks with enabled: false should not appear in benchmark_list."""
+        config = {
+            "benchmarks": [
+                {"name": "batched_gemm", "enabled": True},
+                {"name": "fft", "enabled": False},
+            ]
+        }
+        args = self._apply(th, parser, config)
+        assert len(args.benchmark_list) == 1
+        assert args.benchmark_list[0]['name'] == 'batched_gemm'
+
+    def test_platform_stress_config_loads(self, th, parser):
+        """The platform-stress.yaml config should load and parse correctly."""
+        import os
+        config_path = os.path.join(os.path.dirname(__file__), '..', 'config-examples', 'platform-stress.yaml')
+        if not os.path.exists(config_path):
+            pytest.skip("platform-stress.yaml not found")
+        config = th.load_config(config_path)
+        args = self._apply(th, parser, config)
+        assert args.benchmark_list is not None
+        # Should have 9 benchmarks (2 GEMM + conv + einsum + 2 memory + fft + heat + sparse)
+        assert len(args.benchmark_list) == 9
+        # First two should be batched_gemm with different precisions
+        assert args.benchmark_list[0]['name'] == 'batched_gemm'
+        assert args.benchmark_list[0].get('precision_gemm') == 'float32'
+        assert args.benchmark_list[1]['name'] == 'batched_gemm'
+        assert args.benchmark_list[1].get('precision_gemm') == 'float64'

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -618,9 +618,9 @@ class TestConfigDispatchKeys:
         config = th.load_config(config_path)
         args = self._apply(th, parser, config)
         assert args.benchmark_list is not None
-        # Should have 48 benchmarks (6 GEMM + 6 conv + 6 fft + 6 einsum +
+        # Should have 47 benchmarks (6 GEMM + 6 conv + 5 fft + 6 einsum +
         # 4 memory + 6 heat + 6 schrodinger + 4 atomic + 4 sparse)
-        assert len(args.benchmark_list) == 48
+        assert len(args.benchmark_list) == 47
         # First entries should be batched_gemm across precisions
         assert args.benchmark_list[0]['name'] == 'batched_gemm'
         assert args.benchmark_list[0].get('precision_gemm') == 'bfloat16'

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -618,10 +618,11 @@ class TestConfigDispatchKeys:
         config = th.load_config(config_path)
         args = self._apply(th, parser, config)
         assert args.benchmark_list is not None
-        # Should have 9 benchmarks (2 GEMM + conv + einsum + 2 memory + fft + heat + sparse)
-        assert len(args.benchmark_list) == 9
-        # First two should be batched_gemm with different precisions
+        # Should have 48 benchmarks (6 GEMM + 6 conv + 6 fft + 6 einsum +
+        # 4 memory + 6 heat + 6 schrodinger + 4 atomic + 4 sparse)
+        assert len(args.benchmark_list) == 48
+        # First entries should be batched_gemm across precisions
         assert args.benchmark_list[0]['name'] == 'batched_gemm'
-        assert args.benchmark_list[0].get('precision_gemm') == 'float32'
-        assert args.benchmark_list[1]['name'] == 'batched_gemm'
-        assert args.benchmark_list[1].get('precision_gemm') == 'float64'
+        assert args.benchmark_list[0].get('precision_gemm') == 'bfloat16'
+        assert args.benchmark_list[2]['name'] == 'batched_gemm'
+        assert args.benchmark_list[2].get('precision_gemm') == 'float32'

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -299,3 +299,121 @@ class TestLoadHardwareBaselines:
         """Unknown file format should return empty dict."""
         result = th.load_hardware_baselines("/some/path/file.txt")
         assert result == {}
+
+
+class TestSummaryTableGrouping:
+    """Tests for the multi-GPU summary table grouping logic.
+    
+    Verifies that benchmark results are grouped correctly when
+    multiple config entries share the same name+dtype (e.g.,
+    memory_traffic streaming vs random, both float32).
+    """
+
+    def _make_gpu_result(self, gpu_index, benchmarks, serial='SN123'):
+        """Helper to create a mock GPU result dict."""
+        return {
+            'gpu_index': gpu_index,
+            'serial': serial,
+            'telemetry_stats': {},
+            'benchmarks': benchmarks,
+        }
+
+    def _make_bench(self, name, dtype, mean, unit='GFLOP/s', params=None):
+        """Helper to create a mock benchmark result dict."""
+        p = {'dtype': dtype}
+        if params:
+            p.update(params)
+        return {
+            'name': name,
+            'mean': mean,
+            'min': mean * 0.95,
+            'max': mean * 1.05,
+            'unit': unit,
+            'params': p,
+            'telemetry': {},
+        }
+
+    def test_same_name_dtype_different_index_separate_groups(self):
+        """Two benchmarks with same name+dtype but different positions should be separate groups."""
+        # Simulate two memory_traffic runs (streaming vs random), both float32
+        bench_streaming = self._make_bench('Memory Traffic', 'float32', 500.0, 'GB/s',
+                                           params={'pattern': 'streaming'})
+        bench_random = self._make_bench('Memory Traffic', 'float32', 300.0, 'GB/s',
+                                        params={'pattern': 'random'})
+        
+        # Group by bench_idx as the fix does
+        benchmark_groups = {}
+        results = [
+            self._make_gpu_result(0, [bench_streaming, bench_random]),
+            self._make_gpu_result(1, [bench_streaming, bench_random]),
+        ]
+        
+        for result in results:
+            gpu_idx = result['gpu_index']
+            for bench_idx, bench in enumerate(result.get('benchmarks', [])):
+                if not bench:
+                    continue
+                dtype = bench.get('params', {}).get('dtype', 'unknown')
+                test_key = f"{bench_idx:03d}_{bench['name']}_{dtype}"
+                if test_key not in benchmark_groups:
+                    benchmark_groups[test_key] = {'results': []}
+                benchmark_groups[test_key]['results'].append({'gpu': gpu_idx})
+        
+        # Should have 2 groups, each with 2 GPU entries
+        assert len(benchmark_groups) == 2
+        for group in benchmark_groups.values():
+            assert len(group['results']) == 2
+
+    def test_different_dtype_separate_groups(self):
+        """Two GEMM entries with different dtypes should be separate groups."""
+        bench_fp32 = self._make_bench('Batched GEMM', 'float32', 15000.0)
+        bench_fp64 = self._make_bench('Batched GEMM', 'float64', 7500.0)
+        
+        benchmark_groups = {}
+        results = [self._make_gpu_result(0, [bench_fp32, bench_fp64])]
+        
+        for result in results:
+            for bench_idx, bench in enumerate(result.get('benchmarks', [])):
+                if not bench:
+                    continue
+                dtype = bench.get('params', {}).get('dtype', 'unknown')
+                test_key = f"{bench_idx:03d}_{bench['name']}_{dtype}"
+                if test_key not in benchmark_groups:
+                    benchmark_groups[test_key] = {'results': []}
+                benchmark_groups[test_key]['results'].append({'gpu': result['gpu_index']})
+        
+        assert len(benchmark_groups) == 2
+
+    def test_unique_gpu_count(self):
+        """Aggregate should count unique GPUs, not total result entries."""
+        results_list = [
+            {'gpu': 0, 'performance': 100.0},
+            {'gpu': 1, 'performance': 100.0},
+        ]
+        unique_gpus = len(set(r['gpu'] for r in results_list))
+        assert unique_gpus == 2
+
+    def test_display_label_includes_pattern(self):
+        """Display label for memory_traffic should include pattern info."""
+        bench = self._make_bench('Memory Traffic', 'float32', 500.0, 'GB/s',
+                                 params={'pattern': 'streaming'})
+        params = bench.get('params', {})
+        dtype = params.get('dtype', 'unknown')
+        extra_parts = []
+        if 'pattern' in params:
+            extra_parts.append(params['pattern'])
+        display_label = f"{bench['name']} ({dtype})" if not extra_parts else f"{bench['name']} ({dtype}, {', '.join(extra_parts)})"
+        
+        assert display_label == "Memory Traffic (float32, streaming)"
+
+    def test_display_label_without_pattern(self):
+        """Display label for GEMM should just show name and dtype."""
+        bench = self._make_bench('Batched GEMM', 'float64', 7500.0)
+        params = bench.get('params', {})
+        dtype = params.get('dtype', 'unknown')
+        extra_parts = []
+        if 'pattern' in params:
+            extra_parts.append(params['pattern'])
+        display_label = f"{bench['name']} ({dtype})" if not extra_parts else f"{bench['name']} ({dtype}, {', '.join(extra_parts)})"
+        
+        assert display_label == "Batched GEMM (float64)"

--- a/torch-hammer.py
+++ b/torch-hammer.py
@@ -3102,6 +3102,19 @@ def load_config(config_path):
         sys.exit(1)
 
 
+def _config_get(bench_config, *keys, default=None):
+    """Look up a value in a benchmark config dict, trying multiple key names in order.
+    
+    Supports both short generic keys (e.g., 'precision', 'batch_count') and
+    full argparse attribute names (e.g., 'precision_gemm', 'batch_count_gemm').
+    Returns the value from the first key found, or default if none match.
+    """
+    for key in keys:
+        if key in bench_config:
+            return bench_config[key]
+    return default
+
+
 def apply_config_to_args(args, config):
     """Apply configuration file settings to args namespace. CLI args take precedence."""
     if not config:
@@ -3798,7 +3811,19 @@ def run_single_gpu(args, gpu_index: int, log=None):
             log.info(f"Running {len(benchmark_list)} benchmark(s) from config file:")
             for idx, bench_config in enumerate(benchmark_list):
                 bench_name = bench_config.get('name', 'UNNAMED')
-                precision = bench_config.get('precision', 'default')
+                # Look up precision using both short and full attribute name keys
+                _prec_keys = {
+                    'batched_gemm': ('precision', 'precision_gemm'),
+                    'convolution': ('precision', 'precision_convolution'),
+                    'fft': ('precision', 'precision_fft'),
+                    'einsum': ('precision', 'precision_einsum'),
+                    'memory_traffic': ('precision', 'precision_memory'),
+                    'heat_equation': ('precision', 'precision_heat'),
+                    'schrodinger': ('precision', 'precision_schrodinger'),
+                    'atomic_contention': ('precision', 'precision_atomic'),
+                    'sparse_mm': ('precision', 'precision_sparse'),
+                }
+                precision = _config_get(bench_config, *_prec_keys.get(bench_name, ('precision',)), default='default')
                 log.info(f"  {idx+1}. {bench_name} ({precision})")
             
             # Run benchmarks from config file list (supports multiple instances)
@@ -3818,13 +3843,13 @@ def run_single_gpu(args, gpu_index: int, log=None):
                     original_values['batched_gemm_TF32_mode'] = args.batched_gemm_TF32_mode
                     original_values['inner_loop_batched_gemm'] = args.inner_loop_batched_gemm
                     
-                    args.precision_gemm = bench_config.get('precision', 'float32')
-                    args.batch_count_gemm = bench_config.get('batch_count', args.batch_count_gemm)
-                    args.m = bench_config.get('m', args.m)
-                    args.n = bench_config.get('n', args.n)
-                    args.k = bench_config.get('k', args.k)
-                    args.batched_gemm_TF32_mode = bench_config.get('tf32_mode', False)
-                    args.inner_loop_batched_gemm = bench_config.get('inner_loop', args.inner_loop_batched_gemm)
+                    args.precision_gemm = _config_get(bench_config, 'precision', 'precision_gemm', default='float32')
+                    args.batch_count_gemm = _config_get(bench_config, 'batch_count', 'batch_count_gemm', default=args.batch_count_gemm)
+                    args.m = _config_get(bench_config, 'm', default=args.m)
+                    args.n = _config_get(bench_config, 'n', default=args.n)
+                    args.k = _config_get(bench_config, 'k', default=args.k)
+                    args.batched_gemm_TF32_mode = _config_get(bench_config, 'tf32_mode', 'batched_gemm_TF32_mode', default=False)
+                    args.inner_loop_batched_gemm = _config_get(bench_config, 'inner_loop', 'inner_loop_batched_gemm', default=args.inner_loop_batched_gemm)
                     
                     # DEBUG: Log parameters being used
                     log.info(f"[GPU{gpu_index} GEMM CONFIG] B={args.batch_count_gemm}, M={args.m}, N={args.n}, K={args.k}, dtype={args.precision_gemm}, iters={args.inner_loop_batched_gemm}")
@@ -3851,14 +3876,14 @@ def run_single_gpu(args, gpu_index: int, log=None):
                     original_values['kernel_size'] = args.kernel_size
                     original_values['inner_loop_convolution'] = args.inner_loop_convolution
                     
-                    args.precision_convolution = bench_config.get('precision', 'float32')
-                    args.batch_count_convolution = bench_config.get('batch_count', args.batch_count_convolution)
-                    args.in_channels = bench_config.get('in_channels', args.in_channels)
-                    args.out_channels = bench_config.get('out_channels', args.out_channels)
-                    args.height = bench_config.get('height', args.height)
-                    args.width = bench_config.get('width', args.width)
-                    args.kernel_size = bench_config.get('kernel_size', args.kernel_size)
-                    args.inner_loop_convolution = bench_config.get('inner_loop', args.inner_loop_convolution)
+                    args.precision_convolution = _config_get(bench_config, 'precision', 'precision_convolution', default='float32')
+                    args.batch_count_convolution = _config_get(bench_config, 'batch_count', 'batch_count_convolution', default=args.batch_count_convolution)
+                    args.in_channels = _config_get(bench_config, 'in_channels', default=args.in_channels)
+                    args.out_channels = _config_get(bench_config, 'out_channels', default=args.out_channels)
+                    args.height = _config_get(bench_config, 'height', default=args.height)
+                    args.width = _config_get(bench_config, 'width', default=args.width)
+                    args.kernel_size = _config_get(bench_config, 'kernel_size', default=args.kernel_size)
+                    args.inner_loop_convolution = _config_get(bench_config, 'inner_loop', 'inner_loop_convolution', default=args.inner_loop_convolution)
                     
                     # Reset telemetry stats before benchmark for per-benchmark isolation
                     tel.reset_stats()
@@ -3880,12 +3905,12 @@ def run_single_gpu(args, gpu_index: int, log=None):
                     original_values['nz'] = args.nz
                     original_values['inner_loop_fft'] = args.inner_loop_fft
                     
-                    args.precision_fft = bench_config.get('precision', 'float32')
-                    args.batch_count_fft = bench_config.get('batch_count', args.batch_count_fft)
-                    args.nx = bench_config.get('nx', args.nx)
-                    args.ny = bench_config.get('ny', args.ny)
-                    args.nz = bench_config.get('nz', args.nz)
-                    args.inner_loop_fft = bench_config.get('inner_loop', args.inner_loop_fft)
+                    args.precision_fft = _config_get(bench_config, 'precision', 'precision_fft', default='float32')
+                    args.batch_count_fft = _config_get(bench_config, 'batch_count', 'batch_count_fft', default=args.batch_count_fft)
+                    args.nx = _config_get(bench_config, 'nx', default=args.nx)
+                    args.ny = _config_get(bench_config, 'ny', default=args.ny)
+                    args.nz = _config_get(bench_config, 'nz', default=args.nz)
+                    args.inner_loop_fft = _config_get(bench_config, 'inner_loop', 'inner_loop_fft', default=args.inner_loop_fft)
                     
                     # Reset telemetry stats before benchmark for per-benchmark isolation
                     tel.reset_stats()
@@ -3907,12 +3932,12 @@ def run_single_gpu(args, gpu_index: int, log=None):
                     original_values['d_model'] = args.d_model
                     original_values['inner_loop_einsum'] = args.inner_loop_einsum
                     
-                    args.precision_einsum = bench_config.get('precision', 'float32')
-                    args.batch_count_einsum = bench_config.get('batch_count', args.batch_count_einsum)
-                    args.heads = bench_config.get('heads', args.heads)
-                    args.seq_len = bench_config.get('seq_len', args.seq_len)
-                    args.d_model = bench_config.get('head_dim', args.d_model)
-                    args.inner_loop_einsum = bench_config.get('inner_loop', args.inner_loop_einsum)
+                    args.precision_einsum = _config_get(bench_config, 'precision', 'precision_einsum', default='float32')
+                    args.batch_count_einsum = _config_get(bench_config, 'batch_count', 'batch_count_einsum', default=args.batch_count_einsum)
+                    args.heads = _config_get(bench_config, 'heads', default=args.heads)
+                    args.seq_len = _config_get(bench_config, 'seq_len', default=args.seq_len)
+                    args.d_model = _config_get(bench_config, 'head_dim', 'd_model', default=args.d_model)
+                    args.inner_loop_einsum = _config_get(bench_config, 'inner_loop', 'inner_loop_einsum', default=args.inner_loop_einsum)
                     
                     # Reset telemetry stats before benchmark for per-benchmark isolation
                     tel.reset_stats()
@@ -3930,12 +3955,14 @@ def run_single_gpu(args, gpu_index: int, log=None):
                     original_values['precision_memory'] = args.precision_memory
                     original_values['memory_size'] = args.memory_size
                     original_values['memory_iterations'] = args.memory_iterations
+                    original_values['memory_pattern'] = args.memory_pattern
                     original_values['inner_loop_memory_traffic'] = args.inner_loop_memory_traffic
                     
-                    args.precision_memory = bench_config.get('precision', 'float32')
-                    args.memory_size = bench_config.get('size', args.memory_size)
-                    args.memory_iterations = bench_config.get('iterations', args.memory_iterations)
-                    args.inner_loop_memory_traffic = bench_config.get('inner_loop', args.inner_loop_memory_traffic)
+                    args.precision_memory = _config_get(bench_config, 'precision', 'precision_memory', default='float32')
+                    args.memory_size = _config_get(bench_config, 'size', 'memory_size', default=args.memory_size)
+                    args.memory_iterations = _config_get(bench_config, 'iterations', 'memory_iterations', default=args.memory_iterations)
+                    args.memory_pattern = _config_get(bench_config, 'pattern', 'memory_pattern', default=args.memory_pattern)
+                    args.inner_loop_memory_traffic = _config_get(bench_config, 'inner_loop', 'inner_loop_memory_traffic', default=args.inner_loop_memory_traffic)
                     
                     # Reset telemetry stats before benchmark for per-benchmark isolation
                     tel.reset_stats()
@@ -3957,12 +3984,12 @@ def run_single_gpu(args, gpu_index: int, log=None):
                     original_values['delta_t'] = getattr(args, 'delta_t', 0.01)
                     original_values['inner_loop_heat_equation'] = getattr(args, 'inner_loop_heat_equation', 10)
                     
-                    args.precision_heat = bench_config.get('precision', 'float64')
-                    args.heat_grid_size = bench_config.get('grid_size', getattr(args, 'heat_grid_size', 128))
-                    args.heat_time_steps = bench_config.get('time_steps', getattr(args, 'heat_time_steps', 100))
-                    args.alpha = bench_config.get('alpha', getattr(args, 'alpha', 0.01))
-                    args.delta_t = bench_config.get('delta_t', getattr(args, 'delta_t', 0.01))
-                    args.inner_loop_heat_equation = bench_config.get('inner_loop', getattr(args, 'inner_loop_heat_equation', 10))
+                    args.precision_heat = _config_get(bench_config, 'precision', 'precision_heat', default='float64')
+                    args.heat_grid_size = _config_get(bench_config, 'grid_size', 'heat_grid_size', default=getattr(args, 'heat_grid_size', 128))
+                    args.heat_time_steps = _config_get(bench_config, 'time_steps', 'heat_time_steps', default=getattr(args, 'heat_time_steps', 100))
+                    args.alpha = _config_get(bench_config, 'alpha', default=getattr(args, 'alpha', 0.01))
+                    args.delta_t = _config_get(bench_config, 'delta_t', default=getattr(args, 'delta_t', 0.01))
+                    args.inner_loop_heat_equation = _config_get(bench_config, 'inner_loop', 'inner_loop_heat_equation', default=getattr(args, 'inner_loop_heat_equation', 10))
                     
                     # Reset telemetry stats before benchmark for per-benchmark isolation
                     tel.reset_stats()
@@ -3982,10 +4009,10 @@ def run_single_gpu(args, gpu_index: int, log=None):
                     original_values['schrodinger_time_steps'] = getattr(args, 'schrodinger_time_steps', 100)
                     original_values['inner_loop_schrodinger'] = getattr(args, 'inner_loop_schrodinger', 10)
                     
-                    args.precision_schrodinger = bench_config.get('precision', 'complex128')
-                    args.schrodinger_grid_size = bench_config.get('grid_size', getattr(args, 'schrodinger_grid_size', 128))
-                    args.schrodinger_time_steps = bench_config.get('time_steps', getattr(args, 'schrodinger_time_steps', 100))
-                    args.inner_loop_schrodinger = bench_config.get('inner_loop', getattr(args, 'inner_loop_schrodinger', 10))
+                    args.precision_schrodinger = _config_get(bench_config, 'precision', 'precision_schrodinger', default='complex128')
+                    args.schrodinger_grid_size = _config_get(bench_config, 'grid_size', 'schrodinger_grid_size', default=getattr(args, 'schrodinger_grid_size', 128))
+                    args.schrodinger_time_steps = _config_get(bench_config, 'time_steps', 'schrodinger_time_steps', default=getattr(args, 'schrodinger_time_steps', 100))
+                    args.inner_loop_schrodinger = _config_get(bench_config, 'inner_loop', 'inner_loop_schrodinger', default=getattr(args, 'inner_loop_schrodinger', 10))
                     
                     # Reset telemetry stats before benchmark for per-benchmark isolation
                     tel.reset_stats()
@@ -4006,11 +4033,11 @@ def run_single_gpu(args, gpu_index: int, log=None):
                     original_values['atomic_contention_range'] = getattr(args, 'atomic_contention_range', 1024)
                     original_values['inner_loop_atomic'] = getattr(args, 'inner_loop_atomic', 50)
                     
-                    args.precision_atomic = bench_config.get('precision', 'float32')
-                    args.atomic_target_size = bench_config.get('target_size', getattr(args, 'atomic_target_size', 1_000_000))
-                    args.atomic_num_updates = bench_config.get('num_updates', getattr(args, 'atomic_num_updates', 10_000_000))
-                    args.atomic_contention_range = bench_config.get('contention_range', getattr(args, 'atomic_contention_range', 1024))
-                    args.inner_loop_atomic = bench_config.get('inner_loop', getattr(args, 'inner_loop_atomic', 50))
+                    args.precision_atomic = _config_get(bench_config, 'precision', 'precision_atomic', default='float32')
+                    args.atomic_target_size = _config_get(bench_config, 'target_size', 'atomic_target_size', default=getattr(args, 'atomic_target_size', 1_000_000))
+                    args.atomic_num_updates = _config_get(bench_config, 'num_updates', 'atomic_num_updates', default=getattr(args, 'atomic_num_updates', 10_000_000))
+                    args.atomic_contention_range = _config_get(bench_config, 'contention_range', 'atomic_contention_range', default=getattr(args, 'atomic_contention_range', 1024))
+                    args.inner_loop_atomic = _config_get(bench_config, 'inner_loop', 'inner_loop_atomic', default=getattr(args, 'inner_loop_atomic', 50))
                     
                     # Reset telemetry stats before benchmark for per-benchmark isolation
                     tel.reset_stats()
@@ -4032,12 +4059,12 @@ def run_single_gpu(args, gpu_index: int, log=None):
                     original_values['sparse_density'] = getattr(args, 'sparse_density', 0.01)
                     original_values['inner_loop_sparse'] = getattr(args, 'inner_loop_sparse', 50)
                     
-                    args.precision_sparse = bench_config.get('precision', 'float32')
-                    args.sparse_m = bench_config.get('m', getattr(args, 'sparse_m', 8192))
-                    args.sparse_n = bench_config.get('n', getattr(args, 'sparse_n', 8192))
-                    args.sparse_k = bench_config.get('k', getattr(args, 'sparse_k', 8192))
-                    args.sparse_density = bench_config.get('density', getattr(args, 'sparse_density', 0.01))
-                    args.inner_loop_sparse = bench_config.get('inner_loop', getattr(args, 'inner_loop_sparse', 50))
+                    args.precision_sparse = _config_get(bench_config, 'precision', 'precision_sparse', default='float32')
+                    args.sparse_m = _config_get(bench_config, 'm', 'sparse_m', default=getattr(args, 'sparse_m', 8192))
+                    args.sparse_n = _config_get(bench_config, 'n', 'sparse_n', default=getattr(args, 'sparse_n', 8192))
+                    args.sparse_k = _config_get(bench_config, 'k', 'sparse_k', default=getattr(args, 'sparse_k', 8192))
+                    args.sparse_density = _config_get(bench_config, 'density', 'sparse_density', default=getattr(args, 'sparse_density', 0.01))
+                    args.inner_loop_sparse = _config_get(bench_config, 'inner_loop', 'inner_loop_sparse', default=getattr(args, 'inner_loop_sparse', 50))
                     
                     # Reset telemetry stats before benchmark for per-benchmark isolation
                     tel.reset_stats()
@@ -4600,25 +4627,39 @@ def main():
         log.info("="*80)
         
         if results:
-            # Group benchmarks by test name + precision
+            # Group benchmarks by position index + name + precision.
+            # Using bench_idx ensures that distinct config entries for the same
+            # benchmark+dtype (e.g., memory_traffic streaming vs random) are
+            # displayed as separate tables instead of being merged.
             benchmark_groups = {}
             for result in results:
                 gpu_idx = result['gpu_index']
                 serial = result.get('serial', 'N/A')
                 tel_stats = result.get('telemetry_stats', {})
                 
-                for bench in result.get('benchmarks', []):
+                for bench_idx, bench in enumerate(result.get('benchmarks', [])):
                     if not bench:
                         continue
-                    # Create unique key for each test variant
+                    # Create unique key using position index to avoid merging
+                    # distinct config entries with the same name+dtype
                     dtype = bench.get('params', {}).get('dtype', 'unknown')
-                    test_key = f"{bench['name']}_{dtype}"
+                    test_key = f"{bench_idx:03d}_{bench['name']}_{dtype}"
                     
                     if test_key not in benchmark_groups:
+                        # Build display name with extra context for benchmarks
+                        # that may appear multiple times with different params
+                        display_name = bench['name']
+                        params = bench.get('params', {})
+                        extra_parts = []
+                        if 'pattern' in params:
+                            extra_parts.append(params['pattern'])
+                        display_label = f"{display_name} ({dtype})" if not extra_parts else f"{display_name} ({dtype}, {', '.join(extra_parts)})"
+                        
                         benchmark_groups[test_key] = {
                             'name': bench['name'],
                             'dtype': dtype,
                             'unit': bench['unit'],
+                            'display_label': display_label,
                             'results': []
                         }
                     
@@ -4666,7 +4707,7 @@ def main():
                             r['notes'] = "Fastest"
                 
                 log.info("")
-                log.info(f"Test: {group['name']} ({group['dtype']})")
+                log.info(f"Test: {group['display_label']}")
                 log.info(f"{'GPU':<4} | {'Serial':<12} | {'Performance':<13} | {'Power(avg)':<10} | {'Temp(max)':<9} | {'Status':<6} | Notes")
                 log.info(f"{'-'*4}+{'-'*14}+{'-'*15}+{'-'*12}+{'-'*11}+{'-'*8}+{'-'*20}")
                 
@@ -4692,12 +4733,13 @@ def main():
                     })
                 
                 # Aggregate stats if multi-GPU
-                if len(results_list) > 1:
+                unique_gpus = len(set(r['gpu'] for r in results_list))
+                if unique_gpus > 1:
                     values = [r['performance'] for r in results_list]
                     aggregate = sum(values)
                     cv = (statistics.stdev(values) / statistics.mean(values) * 100.0) if len(values) > 1 else 0.0
                     log.info(f"")
-                    log.info(f"Aggregate: {aggregate:.1f} {group['unit']} across {len(results_list)} GPUs | Variation: CV={cv:.1f}%")
+                    log.info(f"Aggregate: {aggregate:.1f} {group['unit']} across {unique_gpus} GPUs | Variation: CV={cv:.1f}%")
             
             # Optional CSV export
             if hasattr(args, 'summary_csv') and args.summary_csv and csv_data:


### PR DESCRIPTION
## Description

Fixes four related bugs in the config dispatch and multi-GPU summary table:

1. **Config dispatch ignores full attribute name keys** — `run_single_gpu()` only recognized short generic keys (`precision`, `batch_count`) but silently ignored full argparse attribute names (`precision_gemm`, `batch_count_gemm`). Added `_config_get(bench_config, *keys, default=None)` helper and updated all 9 benchmark dispatch blocks to accept both key styles.
2. **`memory_pattern` never read from config** — The `memory_traffic` dispatch block never read `memory_pattern` (or `pattern`) from the config dict. Both streaming and random entries ran with the default pattern. Added save/restore of `args.memory_pattern`.
3. **Summary `test_key` only uses name+dtype** — Two runs of the same benchmark with the same dtype but different params (e.g., memory_traffic streaming vs random) were merged into one group, displaying duplicate GPU rows. Changed `test_key` to include benchmark position index. Added `display_label` with extra context (e.g., pattern for memory_traffic).
4. **Aggregate counts results, not unique GPUs** — `len(results_list)` reported "across 16 GPUs" instead of "across 8 GPUs". Fixed to use `len(set(r['gpu'] for r in results_list))`.

Also adds `config-examples/platform-stress.yaml` — a standardized GPU platform screening config using full attribute name keys — and 16 new unit tests.

## Motivation and Context

When running multi-GPU benchmarks with YAML configs that use full argparse attribute names (e.g., `precision_gemm: float64`), all config values silently fall back to defaults. This causes two GEMM entries configured for float32 and float64 to both run as float32, producing duplicate rows in the summary table. The same issue affects all 9 benchmarks and the `memory_pattern` parameter.

Fixes #19

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Code cleanup / refactoring

## How Has This Been Tested?

- **Hardware**: CPU-only (pytest suite), 8× NVIDIA GPUs (manual validation with platform-stress.yaml)
- **Commands**:
  ```bash
  # Full test suite — 303 passed, 1 skipped
  python -m pytest tests/ -v

  # Coverage check — 60% overall, _config_get() covered
  python -m pytest tests/ --cov=. --cov-report=term-missing

  # Backwards compat — short-key configs still work
  python torch-hammer.py --config config-examples/stress-test.yaml --dry-run

  # New config — full attribute name keys now work
  python torch-hammer.py --config config-examples/platform-stress.yaml --dry-run

  # Multi-GPU — separate summary tables for each config entry
  python torch-hammer.py --config config-examples/platform-stress.yaml --all-gpus
  ```

## Checklist

- [x] My commits are signed (DCO `Signed-off-by` line)
- [x] I have run `python3 -m py_compile torch-hammer.py` with no errors
- [x] I have tested on at least one GPU platform
- [x] I have updated documentation if needed
- [x] My changes don't break existing functionality
- [x] I have added comments for complex code sections

## Screenshots / Output (if applicable)

**Before (duplicate rows per GPU):**
```
Test: Batched GEMM (float32)
GPU  | Serial       | Performance   | Power(avg) | Temp(max) | Status | Notes
----+--------------+---------------+------------+-----------+--------+--------------------
0    | 1563721006933 | 15086.3 GFLOP/s | 169W       | 31C       | PASS   |
0    | 1563721006933 | 15094.4 GFLOP/s | 169W       | 31C       | PASS   | Fastest
1    | 1563721007009 | 14946.9 GFLOP/s | 70W        | 41C       | PASS   |
1    | 1563721007009 | 15089.0 GFLOP/s | 153W       | 43C       | PASS   |
```

**After (separate tables per config entry):**
```
Test: Batched GEMM (float32)
GPU  | Serial       | Performance   | Power(avg) | Temp(max) | Status | Notes
----+--------------+---------------+------------+-----------+--------+--------------------
0    | 1563721006933 | 15086.3 GFLOP/s | 169W       | 31C       | PASS   | Fastest
1    | 1563721007009 | 14946.9 GFLOP/s | 70W        | 41C       | PASS   |

Aggregate: 30033.2 GFLOP/s across 2 GPUs | Variation: CV=0.7%

Test: Batched GEMM (float64)
GPU  | Serial       | Performance   | Power(avg) | Temp(max) | Status | Notes
----+--------------+---------------+------------+-----------+--------+--------------------
0    | 1563721006933 | 7543.2 GFLOP/s  | 165W       | 32C       | PASS   | Fastest
1    | 1563721007009 | 7501.8 GFLOP/s  | 152W       | 43C       | PASS   |

Aggregate: 15045.0 GFLOP/s across 2 GPUs | Variation: CV=0.4%
```
