### PR TITLE
ROCm AMD-SMI fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ ROCM_VER=$(cat /opt/rocm/.info/version | cut -d'-' -f1 | cut -d'.' -f1,2)
 pip install torch --index-url https://download.pytorch.org/whl/rocm${ROCM_VER}
 
 # Add ROCm's amdsmi to Python path (auto-detects Python version)
-export PYTHONPATH=/opt/rocm/lib/$(ls /opt/rocm/lib | grep python):$PYTHONPATH
+export PYTHONPATH="${ROCM_PATH}/share/amd_smi${PYTHONPATH:+:${PYTHONPATH}}"
 ```
 
 #### Apple Silicon (MPS) Setup

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ ROCM_VER=$(cat /opt/rocm/.info/version | cut -d'-' -f1 | cut -d'.' -f1,2)
 pip install torch --index-url https://download.pytorch.org/whl/rocm${ROCM_VER}
 
 # Add ROCm's amdsmi to Python path (auto-detects Python version)
-export PYTHONPATH="${ROCM_PATH}/share/amd_smi${PYTHONPATH:+:${PYTHONPATH}}"
+export PYTHONPATH="/opt/rocm/share/amd_smi${PYTHONPATH:+:${PYTHONPATH}}"
 ```
 
 #### Apple Silicon (MPS) Setup


### PR DESCRIPTION
## Description

Point the python path directory to the amd smi python library.

## Motivation and Context

On my system the readme example is broken:

```
$  echo "/opt/rocm/lib/$(ls /opt/rocm/lib | grep python)"
/opt/rocm/lib/migraphx.cpython-39-x86_64-linux-gnu.so
```

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

Tested on ROCm 7.2
