### PR TITLE
Fix waterfall heatmap colorscale orientation

### DIFF
--- a/reports/hammer_report.py
+++ b/reports/hammer_report.py
@@ -3633,11 +3633,6 @@ function renderWaterfall() {
     [0.45,"#00cccc"],[0.60,"#66cc00"],[0.75,"#cccc00"],
     [0.88,"#cc3300"],[0.95,"#ff3300"],[1.00,"#ffffff"]
   ];
-  // For lower-is-better, reverse the scale
-  if(isLowerBetter(wfMetric)){
-    var rev=colorscale.slice().reverse();
-    colorscale=rev.map(function(c,i){return [i/(rev.length-1),c[1]];});
-  }
   // Compute latest-iteration value per column for spectrum trace (top panel).
   // In waterfall convention the spectrum shows the most recent sweep.
   var colLatest=columns.map(function(c){


### PR DESCRIPTION
## Description

Remove the logic that reversed the waterfall colormap for some metrics (e.g. temeprature,power)
"Lower is better" does not imply that the meaning of the colors should be inverted, red is still considered a correct color for hot, and blue for cold.

## Motivation and Context

Fixes #38 

## Type of Change

<!-- Mark the appropriate option with an [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Code cleanup / refactoring

## How Has This Been Tested?

Generate interactive html pages based on the same dataset.
Observe the waterfall display and colormap when selecting temperature or power.

## Checklist

<!-- Mark completed items with an [x] -->

- [x] My commits are signed (DCO `Signed-off-by` line)
- [x] I have run `python3 -m py_compile torch-hammer.py` with no errors
- [x] I have tested on at least one GPU platform
- [ ] I have updated documentation if needed
- [x] My changes don't break existing functionality
- [ ] I have added comments for complex code sections

## Screenshots / Output (if applicable)

### Before:
<img width="1279" height="708" alt="image" src="https://github.com/user-attachments/assets/dcae33d4-efb2-4a92-a6a8-0c2265d8683f" />

### After:
<img width="1273" height="708" alt="image" src="https://github.com/user-attachments/assets/8fdbe029-2af4-4aa6-a8da-0b88641ad157" />

